### PR TITLE
Ensure slideshow navigation dots match slide count

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,11 +77,8 @@
         <br>
 
         <!-- The dots/circles -->
-        <div style="text-align:center">
-            <span class="dot" onclick="currentSlide(1)"></span>
-            <!-- Add more dots for each slide -->
-        </div>
-    </section>
+        <div id="dots-container" style="text-align:center"></div>
+        </section>
 
     
 

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -1,5 +1,21 @@
 var slideIndex = 1;
+initDots();
 showSlides(slideIndex);
+
+// Dynamically create dot elements based on the number of slides
+function initDots() {
+  var slides = document.getElementsByClassName("mySlides");
+  var dotsContainer = document.getElementById("dots-container");
+  if (!dotsContainer) return;
+
+  dotsContainer.innerHTML = "";
+  for (let i = 0; i < slides.length; i++) {
+    var dot = document.createElement("span");
+    dot.className = "dot";
+    dot.addEventListener("click", function() { currentSlide(i + 1); });
+    dotsContainer.appendChild(dot);
+  }
+}
 
 // Next/previous controls
 function plusSlides(n) {
@@ -15,7 +31,7 @@ function showSlides(n) {
   var i;
   var slides = document.getElementsByClassName("mySlides");
   var dots = document.getElementsByClassName("dot");
-  if (n > slides.length) {slideIndex = 1}    
+  if (n > slides.length) {slideIndex = 1}
   if (n < 1) {slideIndex = slides.length}
   for (i = 0; i < slides.length; i++) {
       slides[i].style.opacity = "0";  
@@ -30,5 +46,7 @@ function showSlides(n) {
   for (i = 0; i < dots.length; i++) {
       dots[i].className = dots[i].className.replace(" active", "");
   }
-  dots[slideIndex-1].className += " active";
+  if (dots.length >= slideIndex) {
+      dots[slideIndex-1].className += " active";
+  }
 }


### PR DESCRIPTION
## Summary
- Dynamically generate navigation dots for the slideshow based on the number of slides.
- Remove hard-coded dot placeholder from `index.html` and safeguard dot activation in `slideshow.js`.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e50233578832b82faf72d73931f9b