### PR TITLE
Fix typo in introduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     </header>
     <section style="color: white;" id="introduction">
         <h2>Welcome to My Portfolio</h2>
-        <p>Driven and detail-oriented, I am a computer science gradute with a focus on engineering and problem-solving. Specializing in machine learning, programming, and performance optimization through parallelism, I bring a wealth of experience in configuring complex systems. As a National Eagle Scout recipient, I demonstrate exceptional leadership and a commitment to excellence. Passionate about pushing the boundaries of technology, I am eager to engage in challenging engineering opportunities, contributing to innovative projects and making a lasting impact.</p>
+        <p>Driven and detail-oriented, I am a computer science graduate with a focus on engineering and problem-solving. Specializing in machine learning, programming, and performance optimization through parallelism, I bring a wealth of experience in configuring complex systems. As a National Eagle Scout recipient, I demonstrate exceptional leadership and a commitment to excellence. Passionate about pushing the boundaries of technology, I am eager to engage in challenging engineering opportunities, contributing to innovative projects and making a lasting impact.</p>
     </section>
     
 


### PR DESCRIPTION
## Summary
- Correct typo: change "gradute" to "graduate" in introduction section.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e51ad228c832baa31a00bbbb8b5f9