### PR TITLE
Handle missing slideshow dots

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,9 @@
         <!-- The dots/circles -->
         <div style="text-align:center">
             <span class="dot" onclick="currentSlide(1)"></span>
-            <!-- Add more dots for each slide -->
+            <span class="dot" onclick="currentSlide(2)"></span>
+            <span class="dot" onclick="currentSlide(3)"></span>
+            <span class="dot" onclick="currentSlide(4)"></span>
         </div>
     </section>
 

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -15,7 +15,7 @@ function showSlides(n) {
   var i;
   var slides = document.getElementsByClassName("mySlides");
   var dots = document.getElementsByClassName("dot");
-  if (n > slides.length) {slideIndex = 1}    
+  if (n > slides.length) {slideIndex = 1}
   if (n < 1) {slideIndex = slides.length}
   for (i = 0; i < slides.length; i++) {
       slides[i].style.opacity = "0";  
@@ -30,5 +30,7 @@ function showSlides(n) {
   for (i = 0; i < dots.length; i++) {
       dots[i].className = dots[i].className.replace(" active", "");
   }
-  dots[slideIndex-1].className += " active";
+  if (dots.length > slideIndex - 1) {
+      dots[slideIndex-1].className += " active";
+  }
 }


### PR DESCRIPTION
## Summary
- Avoid error when a slideshow dot is missing by checking length before accessing it.
- Add navigation dots in `index.html` so each slide has a corresponding dot.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e51b2b674832ba00e71d668c4158e