### PR TITLE
Add mailto link builder and tests

### DIFF
--- a/js/emailMe.js
+++ b/js/emailMe.js
@@ -1,13 +1,21 @@
-document.getElementById("contactForm").addEventListener("submit", function(event){
-    event.preventDefault();
-    
-    var email = document.getElementById("email").value;
-    var subject = document.getElementById("subject").value;
-    var message = document.getElementById("message").value;
+function buildMailtoLink(email, subject, message) {
+    return 'mailto:garrettdipalma2@gmail.com?subject=' + encodeURIComponent(subject) +
+           '&body=' + encodeURIComponent(message + "\n\nFrom: " + email);
+}
 
-    // Construct the mailto link
-    var mailtoLink = 'mailto:garrettdipalma2@gmail.com?subject=' + encodeURIComponent(subject) +
-                     '&body=' + encodeURIComponent(message + "\n\nFrom: " + email);
+// Attach event listener only when running in the browser
+if (typeof document !== 'undefined') {
+    document.getElementById("contactForm").addEventListener("submit", function(event){
+        event.preventDefault();
 
-    window.location.href = mailtoLink; // Open the mailto link
-});
+        var email = document.getElementById("email").value;
+        var subject = document.getElementById("subject").value;
+        var message = document.getElementById("message").value;
+
+        var mailtoLink = buildMailtoLink(email, subject, message);
+
+        window.location.href = mailtoLink; // Open the mailto link
+    });
+}
+
+module.exports = { buildMailtoLink };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "garrett10101.github.io",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/emailMe.test.js
+++ b/tests/emailMe.test.js
@@ -1,0 +1,19 @@
+const { buildMailtoLink } = require('../js/emailMe');
+
+describe('buildMailtoLink', () => {
+  test('returns mailto link with encoded subject and body', () => {
+    const link = buildMailtoLink('user@example.com', 'Hello World', 'This is a message');
+    const expected = 'mailto:garrettdipalma2@gmail.com?subject=' +
+      encodeURIComponent('Hello World') +
+      '&body=' + encodeURIComponent('This is a message\n\nFrom: user@example.com');
+    expect(link).toBe(expected);
+  });
+
+  test('encodes special characters', () => {
+    const link = buildMailtoLink('tester@example.com', 'Hello & Welcome', 'Line1\nLine2?');
+    const expected = 'mailto:garrettdipalma2@gmail.com?subject=' +
+      encodeURIComponent('Hello & Welcome') +
+      '&body=' + encodeURIComponent('Line1\nLine2?\n\nFrom: tester@example.com');
+    expect(link).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- extract mailto link construction into reusable buildMailtoLink function
- add Jest test suite for buildMailtoLink
- configure npm test script using Jest

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e51ba30b8832b82b99656398b1049