### PR TITLE
Hide slides by default for slideshow

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,6 +87,7 @@ footer img {
   
   /* Hide the images by default */
   .mySlides {
+    display: none;
     /* existing styles */
     transition: opacity 0.5s ease; /* Add this line for transition */
     width: 100%;


### PR DESCRIPTION
## Summary
- Ensure slideshow slides are hidden by default with `display: none`.
- Slides remain visible when activated via JavaScript.

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_688e51bd0310832bb82fda215c54e65a