### PR TITLE
Add GitHub contribution activity and expand skills taxonomy

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,22 @@
     <!-- GitHub Projects Section: auto-populated live from the GitHub API, see js/githubProjects.js -->
     <section id="github-projects">
         <h2>Latest from GitHub</h2>
-        <p>Pulled live from <a href="https://github.com/garrett10101" target="_blank">github.com/garrett10101</a> &mdash; updates automatically as new repos are pushed, no redeploy needed.</p>
+        <p>Pulled live from <a href="https://github.com/garrett10101" target="_blank">github.com/garrett10101</a> &mdash; showing the repositories with the most recent activity, updated automatically as new repos are pushed, no redeploy needed.</p>
         <div id="github-repo-list" class="repo-grid"></div>
+
+        <h3>Contribution Activity</h3>
+        <div class="github-activity">
+            <a href="https://github.com/garrett10101" target="_blank" rel="noopener">
+                <img src="https://ghchart.rshah.org/2dd4bf/garrett10101" alt="Garrett's GitHub contribution activity over the past year" loading="lazy">
+            </a>
+        </div>
+
+        <!-- Static note: private-repo work isn't visible to the unauthenticated GitHub API.
+             Edit this blurb to reflect current private engagements. -->
+        <div class="private-activity-note">
+            <span class="private-badge">Private</span>
+            <p>A large share of my recent work lives in <strong>private repositories</strong> that don't appear in the live list above. This includes my Q2 software-engineering role &mdash; building and integrating services with <strong>T-SQL &amp; Microsoft SQL Server</strong> and <strong>SOAP / WSDL / XML</strong> web services under standard <strong>SDLC</strong> practices. The contribution graph above still reflects that activity (as anonymized counts) when private contributions are enabled.</p>
+        </div>
     </section>
 
     <section id="about">

--- a/js/skillsData.js
+++ b/js/skillsData.js
@@ -18,7 +18,8 @@ var SKILLS = [
             { name: "PHP", icon: "img/icons/php.png" },
             { name: "PowerShell", icon: "img/icons/powershell.png" },
             { name: "Python", icon: "img/icons/python.png" },
-            { name: "SQL", icon: "img/icons/sql.jpg" }
+            { name: "SQL", icon: "img/icons/sql.jpg" },
+            { name: "T-SQL" }
         ]
     },
     {
@@ -33,6 +34,7 @@ var SKILLS = [
     {
         category: "Databases & Data Tools",
         skills: [
+            { name: "Microsoft SQL Server" },
             { name: "MySQL", icon: "img/icons/mysql.png" },
             { name: "MySQL Workbench", icon: "img/icons/mysql-workbench.png" },
             { name: "Oracle", icon: "img/icons/oracle.png" }
@@ -58,6 +60,20 @@ var SKILLS = [
             { name: "Geany", icon: "img/icons/geany.png" },
             { name: "Jira", icon: "img/icons/jira.png" },
             { name: "Visual Studio", icon: "img/icons/visual studio.png" }
+        ]
+    },
+    {
+        category: "Web Services & Integration",
+        skills: [
+            { name: "WSDL" },
+            { name: "XML" },
+            { name: "SOAP" }
+        ]
+    },
+    {
+        category: "Methodologies & Concepts",
+        skills: [
+            { name: "SDLC" }
         ]
     }
 ];

--- a/scripts/skillsCategoryMap.js
+++ b/scripts/skillsCategoryMap.js
@@ -12,7 +12,9 @@ var CATEGORY_ORDER = [
     'Frameworks & Libraries',
     'Databases & Data Tools',
     'Systems & DevOps',
-    'Dev & Project Tools'
+    'Dev & Project Tools',
+    'Web Services & Integration',
+    'Methodologies & Concepts'
 ];
 
 // Keyed by normalizeSkillName(name) -> { name, category, icon }
@@ -28,6 +30,7 @@ var SKILL_CATEGORIES = {
     'css': { name: 'CSS', category: 'Languages', icon: 'img/icons/css.png' },
     'bash': { name: 'BASH', category: 'Languages', icon: 'img/icons/bash.png' },
     'sql': { name: 'SQL', category: 'Languages', icon: 'img/icons/sql.jpg' },
+    't-sql': { name: 'T-SQL', category: 'Languages' },
     'powershell': { name: 'PowerShell', category: 'Languages', icon: 'img/icons/powershell.png' },
 
     'flask': { name: 'Flask', category: 'Frameworks & Libraries', icon: 'img/icons/flask.png' },
@@ -36,6 +39,7 @@ var SKILL_CATEGORIES = {
     'matplotlib': { name: 'Matplotlib', category: 'Frameworks & Libraries', icon: 'img/icons/matplotlib.png' },
 
     'oracle': { name: 'Oracle', category: 'Databases & Data Tools', icon: 'img/icons/oracle.png' },
+    'microsoft sql server': { name: 'Microsoft SQL Server', category: 'Databases & Data Tools' },
     'mysql': { name: 'MySQL', category: 'Databases & Data Tools', icon: 'img/icons/mysql.png' },
     'mysql workbench': { name: 'MySQL Workbench', category: 'Databases & Data Tools', icon: 'img/icons/mysql-workbench.png' },
 
@@ -51,20 +55,32 @@ var SKILL_CATEGORIES = {
 
     'jira': { name: 'Jira', category: 'Dev & Project Tools', icon: 'img/icons/jira.png' },
     'visual studio': { name: 'Visual Studio', category: 'Dev & Project Tools', icon: 'img/icons/visual studio.png' },
-    'geany': { name: 'Geany', category: 'Dev & Project Tools', icon: 'img/icons/geany.png' }
+    'geany': { name: 'Geany', category: 'Dev & Project Tools', icon: 'img/icons/geany.png' },
+
+    'wsdl': { name: 'WSDL', category: 'Web Services & Integration' },
+    'xml': { name: 'XML', category: 'Web Services & Integration' },
+    'soap': { name: 'SOAP', category: 'Web Services & Integration' },
+
+    'sdlc': { name: 'SDLC', category: 'Methodologies & Concepts' }
 };
 
 // LinkedIn skill label variants -> canonical key in SKILL_CATEGORIES above.
 var SKILL_ALIASES = {
     'github': 'git/github',
     'git': 'git/github',
-    'ms sql server': 'sql',
-    't-sql': 'sql',
+    'ms sql server': 'microsoft sql server',
+    'sql server': 'microsoft sql server',
+    'mssql': 'microsoft sql server',
+    'transact-sql': 't-sql',
     'shell scripting': 'bash',
     'active directory (ad)': 'active directory',
     'vmware esxi': 'vmware',
     'rest apis': 'api integration',
-    'rest api': 'api integration'
+    'rest api': 'api integration',
+    'soap protocol': 'soap',
+    'soap web services': 'soap',
+    'software development life cycle': 'sdlc',
+    'software development lifecycle': 'sdlc'
 };
 
 if (typeof module !== 'undefined') {

--- a/style.css
+++ b/style.css
@@ -356,6 +356,60 @@ nav ul li a.active {
     text-align: center;
 }
 
+#github-projects h3 {
+    margin-top: var(--space-4);
+    font-size: 1rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.github-activity {
+    margin-top: var(--space-2);
+    overflow-x: auto;
+}
+
+.github-activity a {
+    display: inline-block;
+    min-width: 100%;
+}
+
+.github-activity img {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+}
+
+.private-activity-note {
+    position: relative;
+    margin-top: var(--space-3);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-accent);
+    border-radius: var(--radius-md);
+    padding: var(--space-2);
+    box-shadow: var(--shadow-card);
+}
+
+.private-activity-note p {
+    margin: var(--space-1) 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.95rem;
+}
+
+.private-badge {
+    display: inline-block;
+    background-color: var(--color-accent);
+    color: var(--color-accent-contrast);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 2px 10px;
+    border-radius: 999px;
+}
+
 /* ==========================================================================
    About / Experience / Education
    ========================================================================== */


### PR DESCRIPTION
## Summary
This PR enhances the portfolio with GitHub contribution visualization and expands the skills taxonomy to include web services, integration technologies, and software development methodologies.

## Key Changes

**GitHub Section Enhancements:**
- Added GitHub contribution activity graph visualization using ghchart.rshah.org
- Introduced a "Private Activity Note" section to document private repository work
- Updated the section description to clarify that repos are sorted by recent activity
- Added styling for the contribution graph container, private activity note card, and private badge

**Skills Taxonomy Expansion:**
- Added two new skill categories: "Web Services & Integration" and "Methodologies & Concepts"
- Added new skills: T-SQL, Microsoft SQL Server, WSDL, XML, SOAP, and SDLC
- Updated skill aliases to map various naming conventions to canonical skill entries (e.g., "ms sql server", "sql server", "mssql" → "microsoft sql server")
- Updated both `skillsCategoryMap.js` and `skillsData.js` to maintain consistency

**Styling:**
- Added `.github-activity` styles for horizontal scrolling of contribution graph
- Added `.private-activity-note` card styling with accent border and shadow
- Added `.private-badge` styling for the "PRIVATE" label
- Added `#github-projects h3` styling for section subheadings

## Notable Details
- The private activity note is a static HTML element that can be manually edited to reflect current private work engagements
- The contribution graph uses lazy loading for performance
- Skill aliases now properly handle multiple variations of SQL Server naming conventions
- All new styles follow existing design system variables (spacing, colors, shadows, etc.)

https://claude.ai/code/session_01X1fkUKd3JJcKQFnhekxZQb