### PR TITLE
Add logo icons for Q2 skills; remove private-repo note

### DIFF
--- a/img/icons/sdlc.svg
+++ b/img/icons/sdlc.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="SDLC">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#2E8B57"/>
+  <g transform="translate(20,11)" fill="none" stroke="#ffffff" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+    <polyline points="23 4 23 10 17 10"/>
+    <path d="M20.49 15a9 9 0 1 1 -2.12 -9.36 L23 10"/>
+  </g>
+  <text x="32" y="52" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13" font-weight="700" fill="#ffffff">SDLC</text>
+</svg>

--- a/img/icons/soap.svg
+++ b/img/icons/soap.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="SOAP">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#12897E"/>
+  <g fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="19" y="14" width="26" height="18" rx="2.5"/>
+    <path d="M19.5 16 L32 26 L44.5 16"/>
+  </g>
+  <text x="32" y="49" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="14" font-weight="700" fill="#ffffff">SOAP</text>
+</svg>

--- a/img/icons/sql-server.svg
+++ b/img/icons/sql-server.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Microsoft SQL Server">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#A4171C"/>
+  <g fill="#ffffff">
+    <ellipse cx="32" cy="19" rx="16" ry="6"/>
+    <path d="M16 19 V45 c0 3.3 7.2 6 16 6 s16 -2.7 16 -6 V19 c0 3.3 -7.2 6 -16 6 S16 22.3 16 19 Z"/>
+  </g>
+  <g fill="none" stroke="#A4171C" stroke-width="2.2">
+    <path d="M16 28 c0 3.3 7.2 6 16 6 s16 -2.7 16 -6"/>
+    <path d="M16 37 c0 3.3 7.2 6 16 6 s16 -2.7 16 -6"/>
+  </g>
+</svg>

--- a/img/icons/t-sql.svg
+++ b/img/icons/t-sql.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="T-SQL">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#0E639C"/>
+  <g fill="#ffffff">
+    <ellipse cx="32" cy="16" rx="12" ry="4.5"/>
+    <path d="M20 16 V30 c0 2.5 5.4 4.5 12 4.5 s12 -2 12 -4.5 V16 c0 2.5 -5.4 4.5 -12 4.5 S20 18.5 20 16 Z"/>
+  </g>
+  <path d="M20 23 c0 2.5 5.4 4.5 12 4.5 s12 -2 12 -4.5" fill="none" stroke="#0E639C" stroke-width="1.8"/>
+  <text x="32" y="49" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13.5" font-weight="700" fill="#ffffff">T-SQL</text>
+</svg>

--- a/img/icons/wsdl.svg
+++ b/img/icons/wsdl.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="WSDL">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#5C4B9E"/>
+  <path d="M23 11 h11 l8 8 v16 a2.5 2.5 0 0 1 -2.5 2.5 H23 a2.5 2.5 0 0 1 -2.5 -2.5 V13.5 A2.5 2.5 0 0 1 23 11 Z" fill="#ffffff"/>
+  <path d="M34 11 v8 h8" fill="none" stroke="#5C4B9E" stroke-width="1.6" stroke-linejoin="round"/>
+  <g stroke="#5C4B9E" stroke-width="1.8" stroke-linecap="round">
+    <path d="M25 25 h10"/>
+    <path d="M25 30 h10"/>
+    <path d="M25 35 h6"/>
+  </g>
+  <text x="32" y="52" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12.5" font-weight="700" fill="#ffffff">WSDL</text>
+</svg>

--- a/img/icons/xml.svg
+++ b/img/icons/xml.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="XML">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#E5622A"/>
+  <text x="32" y="29" text-anchor="middle" font-family="Consolas, 'Courier New', monospace" font-size="17" font-weight="700" fill="#ffffff">&lt;/&gt;</text>
+  <text x="32" y="49" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="15" font-weight="700" fill="#ffffff">XML</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -93,13 +93,6 @@
                 <img src="https://ghchart.rshah.org/2dd4bf/garrett10101" alt="Garrett's GitHub contribution activity over the past year" loading="lazy">
             </a>
         </div>
-
-        <!-- Static note: private-repo work isn't visible to the unauthenticated GitHub API.
-             Edit this blurb to reflect current private engagements. -->
-        <div class="private-activity-note">
-            <span class="private-badge">Private</span>
-            <p>A large share of my recent work lives in <strong>private repositories</strong> that don't appear in the live list above. This includes my Q2 software-engineering role &mdash; building and integrating services with <strong>T-SQL &amp; Microsoft SQL Server</strong> and <strong>SOAP / WSDL / XML</strong> web services under standard <strong>SDLC</strong> practices. The contribution graph above still reflects that activity (as anonymized counts) when private contributions are enabled.</p>
-        </div>
     </section>
 
     <section id="about">

--- a/js/skillsData.js
+++ b/js/skillsData.js
@@ -19,7 +19,7 @@ var SKILLS = [
             { name: "PowerShell", icon: "img/icons/powershell.png" },
             { name: "Python", icon: "img/icons/python.png" },
             { name: "SQL", icon: "img/icons/sql.jpg" },
-            { name: "T-SQL" }
+            { name: "T-SQL", icon: "img/icons/t-sql.svg" }
         ]
     },
     {
@@ -34,7 +34,7 @@ var SKILLS = [
     {
         category: "Databases & Data Tools",
         skills: [
-            { name: "Microsoft SQL Server" },
+            { name: "Microsoft SQL Server", icon: "img/icons/sql-server.svg" },
             { name: "MySQL", icon: "img/icons/mysql.png" },
             { name: "MySQL Workbench", icon: "img/icons/mysql-workbench.png" },
             { name: "Oracle", icon: "img/icons/oracle.png" }
@@ -65,15 +65,15 @@ var SKILLS = [
     {
         category: "Web Services & Integration",
         skills: [
-            { name: "WSDL" },
-            { name: "XML" },
-            { name: "SOAP" }
+            { name: "WSDL", icon: "img/icons/wsdl.svg" },
+            { name: "XML", icon: "img/icons/xml.svg" },
+            { name: "SOAP", icon: "img/icons/soap.svg" }
         ]
     },
     {
         category: "Methodologies & Concepts",
         skills: [
-            { name: "SDLC" }
+            { name: "SDLC", icon: "img/icons/sdlc.svg" }
         ]
     }
 ];

--- a/scripts/skillsCategoryMap.js
+++ b/scripts/skillsCategoryMap.js
@@ -30,7 +30,7 @@ var SKILL_CATEGORIES = {
     'css': { name: 'CSS', category: 'Languages', icon: 'img/icons/css.png' },
     'bash': { name: 'BASH', category: 'Languages', icon: 'img/icons/bash.png' },
     'sql': { name: 'SQL', category: 'Languages', icon: 'img/icons/sql.jpg' },
-    't-sql': { name: 'T-SQL', category: 'Languages' },
+    't-sql': { name: 'T-SQL', category: 'Languages', icon: 'img/icons/t-sql.svg' },
     'powershell': { name: 'PowerShell', category: 'Languages', icon: 'img/icons/powershell.png' },
 
     'flask': { name: 'Flask', category: 'Frameworks & Libraries', icon: 'img/icons/flask.png' },
@@ -39,7 +39,7 @@ var SKILL_CATEGORIES = {
     'matplotlib': { name: 'Matplotlib', category: 'Frameworks & Libraries', icon: 'img/icons/matplotlib.png' },
 
     'oracle': { name: 'Oracle', category: 'Databases & Data Tools', icon: 'img/icons/oracle.png' },
-    'microsoft sql server': { name: 'Microsoft SQL Server', category: 'Databases & Data Tools' },
+    'microsoft sql server': { name: 'Microsoft SQL Server', category: 'Databases & Data Tools', icon: 'img/icons/sql-server.svg' },
     'mysql': { name: 'MySQL', category: 'Databases & Data Tools', icon: 'img/icons/mysql.png' },
     'mysql workbench': { name: 'MySQL Workbench', category: 'Databases & Data Tools', icon: 'img/icons/mysql-workbench.png' },
 
@@ -57,11 +57,11 @@ var SKILL_CATEGORIES = {
     'visual studio': { name: 'Visual Studio', category: 'Dev & Project Tools', icon: 'img/icons/visual studio.png' },
     'geany': { name: 'Geany', category: 'Dev & Project Tools', icon: 'img/icons/geany.png' },
 
-    'wsdl': { name: 'WSDL', category: 'Web Services & Integration' },
-    'xml': { name: 'XML', category: 'Web Services & Integration' },
-    'soap': { name: 'SOAP', category: 'Web Services & Integration' },
+    'wsdl': { name: 'WSDL', category: 'Web Services & Integration', icon: 'img/icons/wsdl.svg' },
+    'xml': { name: 'XML', category: 'Web Services & Integration', icon: 'img/icons/xml.svg' },
+    'soap': { name: 'SOAP', category: 'Web Services & Integration', icon: 'img/icons/soap.svg' },
 
-    'sdlc': { name: 'SDLC', category: 'Methodologies & Concepts' }
+    'sdlc': { name: 'SDLC', category: 'Methodologies & Concepts', icon: 'img/icons/sdlc.svg' }
 };
 
 // LinkedIn skill label variants -> canonical key in SKILL_CATEGORIES above.

--- a/style.css
+++ b/style.css
@@ -381,35 +381,6 @@ nav ul li a.active {
     height: auto;
 }
 
-.private-activity-note {
-    position: relative;
-    margin-top: var(--space-3);
-    background-color: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-left: 3px solid var(--color-accent);
-    border-radius: var(--radius-md);
-    padding: var(--space-2);
-    box-shadow: var(--shadow-card);
-}
-
-.private-activity-note p {
-    margin: var(--space-1) 0 0;
-    color: var(--color-text-muted);
-    font-size: 0.95rem;
-}
-
-.private-badge {
-    display: inline-block;
-    background-color: var(--color-accent);
-    color: var(--color-accent-contrast);
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    padding: 2px 10px;
-    border-radius: 999px;
-}
-
 /* ==========================================================================
    About / Experience / Education
    ========================================================================== */


### PR DESCRIPTION
## Summary

Follow-up to #7. Gives the six Q2 SWE skills real logo tiles (they were plain text chips) and removes the private-repository note from the GitHub section.

## Changes

- **New skill logo icons** — hand-crafted SVGs in `img/icons/`, styled to match the existing icon tiles. No official brand logos exist for most of these, so they're a cohesive set of colored badge-glyphs (no third-party marks copied):
  - `t-sql.svg` — blue database cylinder + label (Languages)
  - `sql-server.svg` — red database cylinder (Databases & Data Tools)
  - `wsdl.svg` — purple document · `xml.svg` — orange `</>` · `soap.svg` — teal envelope (Web Services & Integration)
  - `sdlc.svg` — green lifecycle arrow (Methodologies & Concepts)
- **Wired icons** into `js/skillsData.js` and kept `scripts/skillsCategoryMap.js` (the re-import source of truth) in sync.
- **Removed** the private-repo note card from `#github-projects` in `index.html` and its now-unused `.private-activity-note` / `.private-badge` CSS. The contribution activity bar stays.

## Verification

- `npm test` — all 61 Jest tests pass.
- Rendered the Technical Skills section with headless Chromium to confirm the new icons display cleanly alongside the existing logos and land in the correct categories.
- Confirmed no `private-activity-note` markup remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1fkUKd3JJcKQFnhekxZQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1fkUKd3JJcKQFnhekxZQb)_