### PR TITLE
Add .NET, QGIS, and Godot skills with logo icons

### DIFF
--- a/img/icons/dotnet.svg
+++ b/img/icons/dotnet.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label=".NET">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#512BD4"/>
+  <text x="33" y="33" dominant-baseline="central" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="17" font-weight="800" fill="#ffffff">.NET</text>
+</svg>

--- a/img/icons/godot.svg
+++ b/img/icons/godot.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Godot Engine">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#478CBF"/>
+  <!-- side nubs -->
+  <rect x="12" y="23" width="5" height="9" rx="2" fill="#ffffff"/>
+  <rect x="47" y="23" width="5" height="9" rx="2" fill="#ffffff"/>
+  <!-- head -->
+  <rect x="17" y="13" width="30" height="25" rx="9" fill="#ffffff"/>
+  <!-- eyes -->
+  <circle cx="26" cy="24" r="3.6" fill="#478CBF"/>
+  <circle cx="38" cy="24" r="3.6" fill="#478CBF"/>
+  <circle cx="27.1" cy="22.9" r="1.1" fill="#ffffff"/>
+  <circle cx="39.1" cy="22.9" r="1.1" fill="#ffffff"/>
+  <!-- mouth -->
+  <rect x="24" y="31" width="16" height="3.2" rx="1.6" fill="#478CBF"/>
+  <text x="32" y="50" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="12.5" font-weight="700" fill="#ffffff">Godot</text>
+</svg>

--- a/img/icons/qgis.svg
+++ b/img/icons/qgis.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="QGIS">
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#589632"/>
+  <g fill="none" stroke="#ffffff" stroke-width="2.2">
+    <circle cx="32" cy="22" r="9.5"/>
+    <ellipse cx="32" cy="22" rx="3.8" ry="9.5"/>
+    <path d="M22.5 22 h19"/>
+  </g>
+  <text x="32" y="50" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="13" font-weight="700" fill="#ffffff">QGIS</text>
+</svg>

--- a/js/skillsData.js
+++ b/js/skillsData.js
@@ -25,6 +25,7 @@ var SKILLS = [
     {
         category: "Frameworks & Libraries",
         skills: [
+            { name: ".NET", icon: "img/icons/dotnet.svg" },
             { name: "Flask", icon: "img/icons/flask.png" },
             { name: "Matplotlib", icon: "img/icons/matplotlib.png" },
             { name: "Numpy", icon: "img/icons/numpy.png" },
@@ -58,7 +59,9 @@ var SKILLS = [
         category: "Dev & Project Tools",
         skills: [
             { name: "Geany", icon: "img/icons/geany.png" },
+            { name: "Godot", icon: "img/icons/godot.svg" },
             { name: "Jira", icon: "img/icons/jira.png" },
+            { name: "QGIS", icon: "img/icons/qgis.svg" },
             { name: "Visual Studio", icon: "img/icons/visual studio.png" }
         ]
     },

--- a/scripts/skillsCategoryMap.js
+++ b/scripts/skillsCategoryMap.js
@@ -33,6 +33,7 @@ var SKILL_CATEGORIES = {
     't-sql': { name: 'T-SQL', category: 'Languages', icon: 'img/icons/t-sql.svg' },
     'powershell': { name: 'PowerShell', category: 'Languages', icon: 'img/icons/powershell.png' },
 
+    '.net': { name: '.NET', category: 'Frameworks & Libraries', icon: 'img/icons/dotnet.svg' },
     'flask': { name: 'Flask', category: 'Frameworks & Libraries', icon: 'img/icons/flask.png' },
     'pandas': { name: 'Pandas', category: 'Frameworks & Libraries', icon: 'img/icons/pandas.png' },
     'numpy': { name: 'Numpy', category: 'Frameworks & Libraries', icon: 'img/icons/numpy.png' },
@@ -56,6 +57,8 @@ var SKILL_CATEGORIES = {
     'jira': { name: 'Jira', category: 'Dev & Project Tools', icon: 'img/icons/jira.png' },
     'visual studio': { name: 'Visual Studio', category: 'Dev & Project Tools', icon: 'img/icons/visual studio.png' },
     'geany': { name: 'Geany', category: 'Dev & Project Tools', icon: 'img/icons/geany.png' },
+    'godot': { name: 'Godot', category: 'Dev & Project Tools', icon: 'img/icons/godot.svg' },
+    'qgis': { name: 'QGIS', category: 'Dev & Project Tools', icon: 'img/icons/qgis.svg' },
 
     'wsdl': { name: 'WSDL', category: 'Web Services & Integration', icon: 'img/icons/wsdl.svg' },
     'xml': { name: 'XML', category: 'Web Services & Integration', icon: 'img/icons/xml.svg' },
@@ -79,6 +82,11 @@ var SKILL_ALIASES = {
     'rest api': 'api integration',
     'soap protocol': 'soap',
     'soap web services': 'soap',
+    'dotnet': '.net',
+    '.net framework': '.net',
+    '.net core': '.net',
+    'godot engine': 'godot',
+    'qgis desktop': 'qgis',
     'software development life cycle': 'sdlc',
     'software development lifecycle': 'sdlc'
 };


### PR DESCRIPTION
## Summary

Adds three skills to the Technical Skills section, each with a crafted SVG logo tile matching the existing icon style:

| Skill | Category | Icon |
|---|---|---|
| **.NET** | Frameworks & Libraries | purple `.NET` badge (brand color `#512BD4`) |
| **Godot** | Dev & Project Tools | blue robot head + label |
| **QGIS** | Dev & Project Tools | green globe + label |

No official brand marks were copied — these are cohesive hand-crafted badge glyphs in each product's brand color.

## Changes

- New icons in `img/icons/`: `dotnet.svg`, `godot.svg`, `qgis.svg`.
- Wired into `js/skillsData.js` (kept alphabetical within each category).
- Kept `scripts/skillsCategoryMap.js` (the re-import source of truth) in sync — entries plus name-variant aliases (`dotnet`, `.net core`, `godot engine`, `qgis desktop`, etc.).

## Verification

- `npm test` — all 61 Jest tests pass.
- Rendered the Technical Skills section with headless Chromium to confirm the three new icons display cleanly alongside the existing logos and land in the correct categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1fkUKd3JJcKQFnhekxZQb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1fkUKd3JJcKQFnhekxZQb)_